### PR TITLE
Changes to update position method to address #51 and #52

### DIFF
--- a/__tests__/AbstractComponent.test.js
+++ b/__tests__/AbstractComponent.test.js
@@ -40,6 +40,7 @@ describe('<AbstractComponent />', () => {
         setStopAngleSpy.mockClear();
         setRadiusSpy.mockClear();
         setDirectionSpy.mockClear();
+        setLatLngSpy.mockClear();
         testRef = createRef();
         wrapper = mount(
             <Map>
@@ -75,6 +76,10 @@ describe('<AbstractComponent />', () => {
         it('should call the setLatLng method if props change', () => {
             updateProps(wrapper, { position: [51, 0] });
             expect(setLatLngSpy).toHaveBeenCalledWith([51, 0]);
+        });
+        it('should not call the setLatLng method if props do not change', () => {
+            updateProps(wrapper, { position: [51.505, -0.09] });
+            expect(setLatLngSpy).toHaveBeenCalledTimes(0);
         });
         it('should not call the setStartAngle method if props do not change', () => {
             updateProps(wrapper, { startAngle: 90 });

--- a/src/AbstractComponent.js
+++ b/src/AbstractComponent.js
@@ -21,7 +21,11 @@ export default class AbstractComponent extends Path {
         if (fromProps.radius !== radius) {
             this.leafletElement.setRadius(radius);
         }
-        if (fromProps.position !== position) {
+        if (
+            !fromProps.position.every(
+                (v, i) => Math.abs(v - position[i]) < Number.EPSILON
+            )
+        ) {
             this.leafletElement.setLatLng(position);
         }
     }


### PR DESCRIPTION
Hi again,

Strictly speaking comparing arrays as this is not correct.
```javascript
        if (fromProps.position !== position) {
            this.leafletElement.setLatLng(position);
        }
```
It would trigger unnecessary updates.

Each value of position array should be checked instead.

This PR introduces:
1. checking of position values 
2. a test case when position should not be updated
 